### PR TITLE
Capture chapter headers for display

### DIFF
--- a/pptext.go
+++ b/pptext.go
@@ -2122,6 +2122,12 @@ func tcSpacingCheck(wb []string) []string {
 	rs = append(rs, "")
 	rs = append(rs, "----- main text headers -------------------------------------------------------")
 	for _, b := range headerList {
+		// Convert string to rune slice (to handle UTF-8 safely)
+		runes := []rune(b)
+		if len(runes) > 80 {
+			runes = append(runes[:75], []rune("[...]")...)
+		}
+		b = string(runes)
 		rs = append(rs, b)
 	}
 	rs = append(rs, "")


### PR DESCRIPTION
While analyzing the spacing pattern, capture chapter headings (following 4 blank lines) into a list, then output as a section following the spacing pattern output. This ports a feature from pptools (and improves on it).

Similar to the outline feature in pphtml, but for text files.

This code ignores 2 blanks and only looks for 4 blanks. It makes no attempt to outline h3/sections, in other words.

**Testing notes:**

Run on a text file and look at the "main text headers" section in the output (which follows the "spacing pattern" section). It should correlate to the text beginning the chapters in the book. Note that the text is rewrapped such that four blanks followed by this:

```
                             ROMAN CATHOLIC
                              OPPOSITION TO
                           PAPAL INFALLIBILITY
```

Would be reformatted to this in the report:

```
ROMAN CATHOLIC OPPOSITION TO PAPAL INFALLIBILITY
```
